### PR TITLE
Arvados setup: configure systemd-resolved to interoperate with Docker

### DIFF
--- a/arvados-setup/example-inventory.yml
+++ b/arvados-setup/example-inventory.yml
@@ -43,6 +43,9 @@ arvados_cluster_host:
         key: "/etc/ssl/private/{{ inventory_hostname }}.key"
         remote: true
 
+    # Configure the Docker daemon to use 172.17.0.1 as DNS resolver
+    dns_resolver: "172.17.0.1"
+
 
 ### Arvados services ###
 # The rest of the inventory defines the Arvados services to run on the

--- a/arvados-setup/install-pgpi-cluster.yml
+++ b/arvados-setup/install-pgpi-cluster.yml
@@ -16,6 +16,62 @@
 
 - hosts: arvados_cluster_host
   tasks:
+    - name: Create systemd-resolved configuration file directory
+      become: yes
+      ansible.builtin.file:
+        path: "/etc/systemd/resolved.conf.d"
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+
+    - name: Configure systemd-resolved DNS stub listener with Docker daemon
+      become: yes
+      ansible.builtin.copy:
+        dest: "/etc/systemd/resolved.conf.d/docker-listener.conf"
+        content: |
+          [Resolve]
+          DNSStubListenerExtra=172.17.0.1
+        owner: root
+        group: root
+        mode: 0644
+
+    - name: Create service drop-in file directory for systemd-resolved service
+      become: yes
+      ansible.builtin.file:
+        path: "/etc/systemd/systemd-resolved.service.d"
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+
+    - name: Update systemd-resolved drop-in service file
+      become: yes
+      ansible.builtin.copy:
+        dest: "/etc/systemd/systemd-resolved.service.d/after-docker.conf"
+        content: |
+          [Unit]
+          Wants=docker.service
+          After=docker.service
+        owner: root
+        group: root
+        mode: 0644
+
+    - name: Stop Docker service
+      become: yes
+      ansible.builtin.systemd_service:
+        name: docker
+        state: stopped
+
+    - name: Restart systemd-resolved service that now wants Docker
+      become: yes
+      ansible.builtin.systemd_service:
+        name: systemd-resolved
+        daemon_reload: true
+        state: restarted
+
+- hosts: arvados_cluster_host
+  tasks:
     - name: Install arvados-client (for diagnostics)
       become: yes
       ansible.builtin.apt:


### PR DESCRIPTION
Configure the systemd-resolved listener with the (default) Docker bridge network's resolver so that DNS resolution in containers works with the host system. In containers, apps can now resolve Tailnet domains.

Resolves #10.