### PR TITLE
Arvados-setup: Detecting expiring tailscale cert; add renewal cron job.

### DIFF
--- a/arvados-setup/install-pgpi-cluster.yml
+++ b/arvados-setup/install-pgpi-cluster.yml
@@ -1,7 +1,7 @@
 - hosts: arvados_cluster_host
   become: yes
   tags:
-    - tailscacle
+    - tailscale
   vars:
     cert_check_minute: "{{ 60 | random(seed=inventory_hostname) }}"
     cert_check_dow: "{{ 7 | random(seed=inventory_hostname) }}"

--- a/arvados-setup/install-pgpi-cluster.yml
+++ b/arvados-setup/install-pgpi-cluster.yml
@@ -1,7 +1,32 @@
 - hosts: arvados_cluster_host
+  become: yes
+  tags:
+    - tailscacle
+  vars:
+    cert_check_minute: "{{ 60 | random(seed=inventory_hostname) }}"
+    cert_check_dow: "{{ 7 | random(seed=inventory_hostname) }}"
   tasks:
+    - name: Install openssl command line program
+      ansible.builtin.package:
+        name: openssl
+        state: present
+
+    - name: Inspect any existing cert with openssl
+      ansible.builtin.command:
+        argv:
+          - openssl
+          - x509
+          - -noout
+          - -checkend
+          - "{{ 10 * 86400 }}"
+          - -in
+          - "{{ arvados_tls.Default.cert }}"
+      register: tailscale_cert_expiry_status
+      changed_when: False
+      ignore_errors: yes
+
     - name: Install tailscale cert
-      become: yes
+      when: tailscale_cert_expiry_status.rc != 0
       ansible.builtin.command:
         argv:
           - tailscale
@@ -9,9 +34,16 @@
           - "--cert-file={{ arvados_tls.Default.cert }}"
           - "--key-file={{ arvados_tls.Default.key }}"
           - "{{ inventory_hostname }}"
-        creates: "{{ arvados_tls.Default.key }}"
-      tags:
-        - tailscale
+
+    - name: Install tailscale cert renewal cron job
+      ansible.builtin.cron:
+        name: "Renew tailscale HTTPS certificates"
+        cron_file: tailscale-cert-renew
+        user: root
+        hour: "0"
+        minute: "{{ cert_check_minute }}"
+        weekday: "{{ cert_check_dow }}"
+        job: "openssl x509 -noout -checkend {{ 8 * 86400 }} -in {{ arvados_tls.Default.cert }} 1> /dev/null 2>&1 || tailscale cert --cert-file={{ arvados_tls.Default.cert }} --key-file={{ arvados_tls.Default.key }} {{ inventory_hostname }}"
 
 - name: Install Arvados cluster
   ansible.builtin.import_playbook: "{{ arvados_srcdir|default(lookup('ansible.builtin.env', 'HOME') ~ '/arvados') }}/tools/ansible/install-arvados-cluster.yml"


### PR DESCRIPTION
- When installing the cluster, if the cert is expiring in 10 days, renew them. Previously, the presence of the cert private key file prevents installation of new cert, and the expiry date is not checked.
- Add a cron job to renew the cert. To spread the load and prevent 'resonance' (spike of activity that happens on the same day or hour), the renewal is spread to different days of the week. It will happen at midnight (0hr, but at a random minute).

Resolves #13.